### PR TITLE
Add support for global engine 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Full working references are available at [examples](examples)
 | cluster\_parameters | List of custom cluster parameters to apply to the parameter group. | list | `<list>` | no |
 | db\_snapshot\_arn | The identifier for the DB cluster snapshot from which you want to restore. | string | `""` | no |
 | dbname | The DB name to create. If omitted, no database is created initially | string | `""` | no |
-| engine | Database Engine Type.  Allowed values: aurora-mysql, aurora-postgresql, aurora | string | `"aurora-mysql"` | no |
+| engine | Database Engine Type.  Allowed values: aurora-mysql, aurora, aurora-postgresql | string | `"aurora-mysql"` | no |
+| engine\_mode | The database engine mode. Allowed values: provisioned and global(aurora engine only). | string | `"provisioned"` | no |
 | engine\_version | Database Engine Minor Version http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html | string | `""` | no |
 | environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `"Development"` | no |
 | existing\_cluster\_parameter\_group\_name | The existing cluster parameter group to use for this instance. (OPTIONAL) | string | `""` | no |
@@ -47,6 +48,7 @@ Full working references are available at [examples](examples)
 | existing\_parameter\_group\_name | The existing parameter group to use for this instance. (OPTIONAL) | string | `""` | no |
 | existing\_subnet\_group | The existing DB subnet group to use for this cluster (OPTIONAL) | string | `""` | no |
 | family | Parameter Group Family Name (ex. aurora5.6, aurora-postgresql9.6, aurora-mysql5.7) | string | `""` | no |
+| global\_cluster\_identifier | Global Cluster identifier. Property of aws_rds_global_cluster (Ignored if engine_mode is not 'global'). | string | `""` | no |
 | instance\_class | The database instance type. | string | n/a | yes |
 | kms\_key\_id | KMS Key Arn to use for storage encryption. (OPTIONAL) | string | `""` | no |
 | maintenance\_window | The weekly time range (in UTC) during which system maintenance can occur. | string | `"Sun:07:00-Sun:08:00"` | no |

--- a/examples/aurora.tf
+++ b/examples/aurora.tf
@@ -32,7 +32,7 @@ module "vpc_dr" {
 }
 
 module "aurora_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.3"
 
   ##################
   # Required Configuration
@@ -123,7 +123,7 @@ data "aws_kms_alias" "rds_crr" {
 }
 
 module "aurora_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.3"
 
   providers = {
     aws = "aws.oregon"

--- a/examples/aurora_postgres.tf
+++ b/examples/aurora_postgres.tf
@@ -22,7 +22,7 @@ module "vpc" {
 }
 
 module "aurora_postgresql_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.3"
 
   ##################
   # Required Configuration

--- a/examples/global_aurora.tf
+++ b/examples/global_aurora.tf
@@ -1,11 +1,12 @@
 provider "aws" {
-  version = "~> 1.2"
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 
 provider "aws" {
-  region = "us-west-2"
-  alias  = "oregon"
+  alias   = "secondary"
+  version = "~> 2.0"
+  region  = "us-west-2"
 }
 
 data "aws_kms_secrets" "rds_credentials" {
@@ -13,6 +14,10 @@ data "aws_kms_secrets" "rds_credentials" {
     name    = "password"
     payload = "AQICAHj9P8B8y7UnmuH+/93CxzvYyt+la85NUwzunlBhHYQwSAG+eG8tr978ncilIYv5lj1OAAAAaDBmBgkqhkiG9w0BBwagWTBXAgEAMFIGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMoasNhkaRwpAX9sglAgEQgCVOmIaSSj/tJgEE5BLBBkq6FYjYcUm6Dd09rGPFdLBihGLCrx5H"
   }
+}
+
+resource "aws_rds_global_cluster" "example" {
+  global_cluster_identifier = "global-aurora-example"
 }
 
 module "vpc" {
@@ -25,27 +30,29 @@ module "vpc_dr" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.1"
 
   providers = {
-    aws = "aws.oregon"
+    aws = "aws.secondary"
   }
 
   vpc_name = "Test2VPC"
 }
 
-module "aurora_mysql_master" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.3"
+module "aurora_primary" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=ref=v0.0.4"
 
   ##################
   # Required Configuration
   ##################
 
-  subnets           = "${module.vpc.private_subnets}"
-  security_groups   = ["${module.vpc.default_sg}"]
-  name              = "sample-aurora-mysql-master"
-  engine            = "aurora-mysql"
-  instance_class    = "db.t2.medium"
-  storage_encrypted = true
-  binlog_format     = "MIXED"
-  password          = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
+  subnets                   = "${module.vpc.private_subnets}"
+  security_groups           = ["${module.vpc.default_sg}"]
+  name                      = "aurora-primary"
+  engine                    = "aurora"
+  instance_class            = "db.r3.large"
+  storage_encrypted         = false
+  binlog_format             = "MIXED"
+  password                  = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
+  global_cluster_identifier = "${aws_rds_global_cluster.example.id}"
+  engine_mode               = "global"
 
   ##################
   # VPC Configuration
@@ -67,7 +74,7 @@ module "aurora_mysql_master" {
   ##################
 
   # dbname         = "mydb"
-  # engine_version = "5.7.12"
+  # engine_version = "5.6.10a"
   # port           = "3306"
 
   ##################
@@ -77,7 +84,7 @@ module "aurora_mysql_master" {
   # publicly_accessible                   = false
   # binlog_format                         = "OFF"
   # auto_minor_version_upgrade            = true
-  # family                                = "aurora-mysql5.7"
+  # family                                = "aurora5.6"
   # replica_instances                     = 1
   # storage_encrypted                     = false
   # kms_key_id                            = "some-kms-key-id"
@@ -117,65 +124,73 @@ module "aurora_mysql_master" {
   # }
 }
 
-data "aws_kms_alias" "rds_crr" {
-  provider = "aws.oregon"
-  name     = "alias/aws/rds"
-}
+#undo
+#data "aws_kms_alias" "rds_crr" {
+#  provider = "aws.oregon"
+#  name     = "alias/aws/rds"
+#}
 
-module "aurora_mysql_replica" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.0.3"
+module "aurora_secondary" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=ref=v0.0.4"
 
   providers = {
-    aws = "aws.oregon"
+    aws = "aws.secondary"
   }
 
   ##################
   # Required Configuration
   ##################
 
-  subnets           = "${module.vpc_dr.private_subnets}"
-  security_groups   = ["${module.vpc_dr.default_sg}"]
-  name              = "sample-aurora-mysql-replica"
-  engine            = "aurora-mysql"
-  instance_class    = "db.t2.medium"
-  storage_encrypted = true
-  kms_key_id        = "${data.aws_kms_alias.rds_crr.target_key_arn}"
-  binlog_format     = "MIXED"
-  password          = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
-  source_cluster    = "${module.aurora_mysql_master.cluster_id}"
-  source_region     = "${data.aws_region.current.name}"
+  subnets                   = "${module.vpc_dr.private_subnets}"
+  security_groups           = ["${module.vpc_dr.default_sg}"]
+  name                      = "aurora-secondary"
+  engine                    = "aurora"
+  instance_class            = "db.r3.large"
+  storage_encrypted         = false
+  binlog_format             = "MIXED"
+  password                  = ""
+  username                  = ""
+  global_cluster_identifier = "${aws_rds_global_cluster.example.id}"
+  engine_mode               = "global"
 
   ##################
   # VPC Configuration
   ##################
 
+
   # existing_subnet_group = "some-subnet-group-name"
+
 
   ##################
   # Backups and Maintenance
   ##################
+
 
   # maintenance_window      = "Sun:07:00-Sun:08:00"
   # backup_retention_period = 35
   # backup_window           = "05:00-06:00"
   # db_snapshot_arn          = "some-cluster-snapshot-arn"
 
+
   ##################
   # Basic RDS
   ##################
 
+
   # dbname         = "mydb"
-  # engine_version = "5.7.12"
+  # engine_version = "5.6.10a"
   # port           = "3306"
+
 
   ##################
   # RDS Advanced
   ##################
 
+
   # publicly_accessible                   = false
   # binlog_format                         = "OFF"
   # auto_minor_version_upgrade            = true
-  # family                                = "aurora-mysql5.7"
+  # family                                = "aurora5.6"
   # replica_instances                     = 1
   # storage_encrypted                     = false
   # kms_key_id                            = "some-kms-key-id"
@@ -186,9 +201,11 @@ module "aurora_mysql_replica" {
   # options                               = []
   # existing_option_group_name            = "some-option-group-name"
 
+
   ##################
   # RDS Monitoring
   ##################
+
 
   # notification_topic           = "arn:aws:sns:<region>:<account>:some-topic"
   # alarm_write_iops_limit       = 100000
@@ -198,19 +215,24 @@ module "aurora_mysql_replica" {
   # monitoring_interval          = 0
   # existing_monitoring_role_arn = ""
 
+
   ##################
   # Authentication information
   ##################
 
+
   # username = "dbadmin"
+
 
   ##################
   # Other parameters
   ##################
 
+
   # environment = "Production"
 
-  # tags = {
-  #   SomeTag = "SomeValue"
-  # }
+  # HACK to give me a dependency between modules 
+  tags = {
+    FakeDependency = "${module.aurora_primary.cluster_id}"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  is_postgres = "${var.engine == "aurora-postgres"}" # Allows setting postgres speciffic options
+  is_postgres = "${var.engine == "aurora-postgres"}" # Allows setting postgres specific options
 
   # This map allows setting engine defaults.  Should be updated as new engine versions are released
   engine_defaults = {
@@ -39,12 +39,12 @@ locals {
     }
 
     aurora-mysql = {
-      version = "5.7.12"
+      version = "5.7.mysql_aurora.2.04.1"
     }
 
     aurora-postgresql = {
       port    = "5432"
-      version = "9.6.8"
+      version = "10.7"
     }
   }
 
@@ -53,6 +53,9 @@ locals {
   port = "${coalesce(var.port, lookup(local.engine_defaults[var.engine], "port", "3306"))}"
 
   engine_version = "${coalesce(var.engine_version, lookup(local.engine_defaults[var.engine], "version"))}"
+
+  global_cluster_identifier = "${var.engine_mode == "global" ? var.global_cluster_identifier : ""}"
+  backtrack_support         = "${var.engine_mode == "aurora" && var.engine_mode == "provisioned" ? true : false}"
 
   tags {
     Name            = "${var.name}"
@@ -197,10 +200,12 @@ locals {
 
 resource "aws_rds_cluster" "db_cluster" {
   cluster_identifier_prefix = "${var.name}-"
+  global_cluster_identifier = "${local.global_cluster_identifier}"
 
   engine         = "${var.engine}"
   engine_version = "${local.engine_version}"
   port           = "${local.port}"
+  engine_mode    = "${var.engine_mode}"
 
   storage_encrypted = "${var.storage_encrypted}"
   kms_key_id        = "${var.kms_key_id}"
@@ -219,7 +224,7 @@ resource "aws_rds_cluster" "db_cluster" {
 
   backup_retention_period      = "${var.backup_retention_period}"
   preferred_backup_window      = "${var.backup_window}"
-  backtrack_window             = "${var.engine == "aurora" ? var.backtrack_window: 0 }"
+  backtrack_window             = "${local.backtrack_support ? var.backtrack_window: 0 }"
   preferred_maintenance_window = "${var.maintenance_window}"
   skip_final_snapshot          = "${local.read_replica || var.skip_final_snapshot}"
   final_snapshot_identifier    = "${var.name}-final-snapshot"

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,12 @@ locals {
     }
 
     aurora-mysql = {
-      version = "5.7.mysql_aurora.2.04.1"
+      version = "5.7.12"
     }
 
     aurora-postgresql = {
       port    = "5432"
-      version = "10.7"
+      version = "9.6.8"
     }
   }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -3,6 +3,10 @@ provider "aws" {
   region  = "us-west-2"
 }
 
+provider "random" {
+  version = "~> 2.0"
+}
+
 resource "random_string" "password" {
   length      = 16
   special     = false
@@ -11,10 +15,17 @@ resource "random_string" "password" {
   min_numeric = 1
 }
 
+resource "random_string" "name_rstring" {
+  length  = 6
+  special = false
+  number  = false
+  upper   = false
+}
+
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
 
-  vpc_name = "Aurora-Test1VPC"
+  vpc_name = "${random_string.name_rstring.result}-Aurora-Test1VPC"
 }
 
 module "aurora_master" {
@@ -22,7 +33,7 @@ module "aurora_master" {
 
   subnets             = "${module.vpc.private_subnets}"
   security_groups     = ["${module.vpc.default_sg}"]
-  name                = "test1-aurora-master"
+  name                = "${random_string.name_rstring.result}-test-aurora"
   engine              = "aurora"
   instance_class      = "db.t2.medium"
   storage_encrypted   = true

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "dbname" {
 }
 
 variable "engine" {
-  description = "Database Engine Type.  Allowed values: aurora-mysql, aurora-postgresql, aurora"
+  description = "Database Engine Type.  Allowed values: aurora-mysql, aurora, aurora-postgresql"
   type        = "string"
   default     = "aurora-mysql"
 }
@@ -72,6 +72,12 @@ variable "engine_version" {
   description = "Database Engine Minor Version http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html"
   type        = "string"
   default     = ""
+}
+
+variable "engine_mode" {
+  description = "The database engine mode. Allowed values: provisioned and global(aurora engine only)."
+  type        = "string"
+  default     = "provisioned"
 }
 
 variable "instance_class" {
@@ -86,6 +92,12 @@ variable "name" {
 
 variable "port" {
   description = "The port on which the DB accepts connections"
+  type        = "string"
+  default     = ""
+}
+
+variable "global_cluster_identifier" {
+  description = "Global Cluster identifier. Property of aws_rds_global_cluster (Ignored if engine_mode is not 'global')."
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/227
##### Summary of change(s):
- Add support for global  engine mode my exposing that property
- Freshen the engines  versions

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
- Updating pinned version with an unspecified engine version would lead to replacement 
- engine_mode  silently defaulted to provisoned, I've now made that explicit so this should not have any effect.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
- Example of Global usage will be added
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.