### PR TITLE
fix postgres detection used for internal variables

### DIFF
--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -64,3 +64,17 @@ module "aurora_master_with_replicas" {
   storage_encrypted   = true
   subnets             = "${module.vpc.private_subnets}"
 }
+
+module "aurora_postgres" {
+  source = "../../module"
+
+  engine              = "aurora-postgresql"
+  engine_version      = "11.4"
+  instance_class      = "db.t3.medium"
+  name                = "${random_string.name_rstring.result}-test-aurora-3"
+  password            = "${random_string.password.result}"
+  security_groups     = ["${module.vpc.default_sg}"]
+  skip_final_snapshot = true
+  storage_encrypted   = true
+  subnets             = "${module.vpc.private_subnets}"
+}


### PR DESCRIPTION
##### Corresponding Issue(s):
https://jira.rax.io/browse/MPCSUPENG-924
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/271

##### Summary of change(s):
- fix postgres detection used for internal variable calculations. We have been using  ```aurora-postgres```  in our check when it should be  ```aurora-postgresql```
-  make compatible for postgres 9.x thru 11.x. The versioning of postgres sort of changed semantics  from version 9 to 10.  In some cases  major.min version is needed for 9 where only major is needed for 10>.  A new internal variable ```  family_version ``` was added to help with this.
- add a test for postgres 11
##### Reason for Change(s):
Terraform applies failed on postgres builds due to the wrong major_version being passed to API (e.g. 11.4 vs 11)

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
No
##### Do examples need to be updated based on changes?
No
