### PR TITLE
enforce service level backup window constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | alarm\_write\_io\_limit | CloudWatch Write IOPSLimit Threshold | string | `"100000"` | no |
 | auto\_minor\_version\_upgrade | Boolean value that indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `"true"` | no |
 | backtrack\_window | The target backtrack window, in seconds.  Defaults to 1 day. Setting only affects supported versions (currently MySQL 5.6). Disable by setting to '0'. | string | `"86400"` | no |
-| backup\_retention\_period | The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups. Compass best practice is 30 or more days. | string | `"35"` | no |
+| backup\_retention\_period | The number of days for which automated backups are retained. The permissible range is a value between 1-35. The aurora service defaults to 1 day but this module defaults to 35. Rackspace best practice is 30+ days. | string | `"35"` | no |
 | backup\_window | The daily time range during which automated backups are created if automated backups are enabled. | string | `"05:00-06:00"` | no |
 | binlog\_format | Sets the desired format. Defaults to OFF. Should be set to MIXED if this Aurora cluster will replicate to another RDS Instance or cluster. Ignored for aurora-postgresql engine | string | `"OFF"` | no |
 | cloudwatch\_logs\_exports | List of log types to export to cloudwatch. If omitted, no logs will be exported. The following log types are supported: `audit`, `error`, `general`, `slowquery`. | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -245,7 +245,7 @@ resource "aws_rds_cluster" "db_cluster" {
   db_subnet_group_name            = "${local.subnet_group}"
   db_cluster_parameter_group_name = "${local.cluster_parameter_group}"
 
-  backup_retention_period      = "${var.backup_retention_period}"
+  backup_retention_period      = "${var.backup_retention_period > 1 && var.backup_retention_period  <= 35 ? var.backup_retention_period : 35 }"
   preferred_backup_window      = "${var.backup_window}"
   backtrack_window             = "${local.backtrack_support ? var.backtrack_window: 0 }"
   preferred_maintenance_window = "${var.maintenance_window}"

--- a/main.tf
+++ b/main.tf
@@ -245,7 +245,7 @@ resource "aws_rds_cluster" "db_cluster" {
   db_subnet_group_name            = "${local.subnet_group}"
   db_cluster_parameter_group_name = "${local.cluster_parameter_group}"
 
-  backup_retention_period      = "${var.backup_retention_period > 1 && var.backup_retention_period  <= 35 ? var.backup_retention_period : 35 }"
+  backup_retention_period      = "${var.backup_retention_period >= 1 && var.backup_retention_period  <= 35 ? var.backup_retention_period : 35 }"
   preferred_backup_window      = "${var.backup_window}"
   backtrack_window             = "${local.backtrack_support ? var.backtrack_window: 0 }"
   preferred_maintenance_window = "${var.maintenance_window}"

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -23,7 +23,7 @@ resource "random_string" "name_rstring" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.10"
 
   vpc_name = "${random_string.name_rstring.result}-Aurora-Test1VPC"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "subnets" {
 #########################
 
 variable "backup_retention_period" {
-  description = "The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups. Compass best practice is 30 or more days."
+  description = "The number of days for which automated backups are retained. The permissible range is a value between 1-35. The aurora service defaults to 1 day but this module defaults to 35. Rackspace best practice is 30+ days."
   type        = "string"
   default     = 35
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/273


##### Summary of change(s):
- This is a maintenance update to the otherwise frozen  0.11 branch
- update verbiage to indicate the proper permissible range for `backup_retention_period`
- add a conditional check to set r `backup_retention_period` to `35` if an out of range value is provided.
##### Reason for Change(s):

we were allowing values such as `0` and this was erroring on terraform apply as the AWS api was rejecting an out of bounds value.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes
##### Do examples need to be updated based on changes?
No

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
