### PR TITLE
[TF 0.12] Adjust examples to Rackspace standards

### DIFF
--- a/examples/aurora.tf
+++ b/examples/aurora.tf
@@ -3,13 +3,13 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.1"
   region  = "us-east-1"
+  version = "~> 2.1"
 }
 
 provider "aws" {
-  region = "us-west-2"
   alias  = "oregon"
+  region = "us-west-2"
 }
 
 data "aws_kms_secrets" "rds_credentials" {
@@ -22,17 +22,17 @@ data "aws_kms_secrets" "rds_credentials" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
 
-  vpc_name = "Test1VPC"
+  name = "Test1VPC"
 }
 
 module "vpc_dr" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
 
   providers = {
-    aws = "aws.oregon"
+    aws = aws.oregon
   }
 
-  vpc_name = "Test2VPC"
+  name = "Test2VPC"
 }
 
 module "aurora_master" {
@@ -42,15 +42,14 @@ module "aurora_master" {
   # Required Configuration
   ##################
 
-  subnets           = "${module.vpc.private_subnets}"
-  security_groups   = ["${module.vpc.default_sg}"]
-  name              = "sample-aurora-master"
+  binlog_format     = "MIXED"
   engine            = "aurora"
   instance_class    = "db.t2.medium"
+  name              = "sample-aurora-master"
+  password          = data.aws_kms_secrets.rds_credentials.plaintext["password"]
+  security_groups   = [module.vpc.default_sg]
   storage_encrypted = true
-  binlog_format     = "MIXED"
-  password          = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
-
+  subnets           = module.vpc.private_subnets
   ##################
   # VPC Configuration
   ##################
@@ -61,10 +60,10 @@ module "aurora_master" {
   # Backups and Maintenance
   ##################
 
-  # maintenance_window      = "Sun:07:00-Sun:08:00"
   # backup_retention_period = 35
   # backup_window           = "05:00-06:00"
   # db_snapshot_arn          = "some-cluster-snapshot-arn"
+  # maintenance_window      = "Sun:07:00-Sun:08:00"
 
   ##################
   # Basic RDS
@@ -72,42 +71,42 @@ module "aurora_master" {
 
   # dbname         = "mydb"
   # engine_version = "5.6.10a"
-  # port           = "3306"
-  # replica_instances                        = 2
   # instance_availability_zone_list          = ["us-west-2a", "us-west-2b", "us-west-2a"]
+  # replica_instances                        = 2
+  # port           = "3306"
 
   ##################
   # RDS Advanced
   ##################
 
-  # publicly_accessible                   = false
-  # binlog_format                         = "OFF"
   # auto_minor_version_upgrade            = true
-  # family                                = "aurora5.6"
-  # replica_instances                     = 1
-  # storage_encrypted                     = false
-  # kms_key_id                            = "some-kms-key-id"
-  # parameters                            = []
-  # existing_parameter_group_name         = "some-parameter-group-name"
+  # binlog_format                         = "OFF"
   # cluster_parameters                    = []
   # existing_cluster_parameter_group_name = "some-parameter-group-name"
-  # options                               = []
   # existing_option_group_name            = "some-option-group-name"
+  # existing_parameter_group_name         = "some-parameter-group-name"
+  # family                                = "aurora5.6"
+  # kms_key_id                            = "some-kms-key-id"
+  # options                               = []
+  # parameters                            = []
+  # publicly_accessible                   = false
+  # replica_instances                     = 1
+  # storage_encrypted                     = false
 
   ##################
   # RDS Monitoring
   ##################
 
-  # notification_topic              = "arn:aws:sns:<region>:<account>:some-topic"
-  # alarm_write_iops_limit          = 100000
-  # alarm_read_iops_limit           = 100000
   # alarm_cpu_limit                 = 60
-  # rackspace_alarms_enabled        = false
-  # monitoring_interval             = 0
-  # existing_monitoring_role_arn    = ""
+  # alarm_read_iops_limit           = 100000
+  # alarm_write_iops_limit          = 100000
   # cloudwatch_logs_exports         = []
+  # existing_monitoring_role_arn    = ""
+  # monitoring_interval             = 0
+  # notification_topic              = "arn:aws:sns:<region>:<account>:some-topic"
   # performance_insights_enable     = false
   # performance_insights_kms_key_id = ""
+  # rackspace_alarms_enabled        = false
 
   ##################
   # Authentication information
@@ -127,99 +126,99 @@ module "aurora_master" {
 }
 
 data "aws_kms_alias" "rds_crr" {
-  provider = "aws.oregon"
   name     = "alias/aws/rds"
+  provider = aws.oregon
 }
 
 module "aurora_replica" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.12.1"
 
   providers = {
-    aws = "aws.oregon"
+    aws = aws.oregon
+    ##################
+    # Required Configuration
+    ##################
+
+    ##################
+    # VPC Configuration
+    ##################
+
+    # existing_subnet_group = "some-subnet-group-name"
+
+    ##################
+    # Backups and Maintenance
+    ##################
+
+    # backup_retention_period = 35
+    # backup_window           = "05:00-06:00"¥
+    # db_snapshot_arn          = "some-cluster-snapshot-arn"
+    # maintenance_window      = "Sun:07:00-Sun:08:00"
+
+    ##################
+    # Basic RDS
+    ##################
+
+    # dbname         = "mydb"
+    # engine_version = "5.6.10a"
+    # port           = "3306"
+
+    ##################
+    # RDS Advanced
+    ##################
+
+    # auto_minor_version_upgrade            = true
+    # binlog_format                         = "OFF"
+    # cluster_parameters                    = []
+    # existing_cluster_parameter_group_name = "some-parameter-group-name"
+    # existing_option_group_name            = "some-option-group-name"
+    # existing_parameter_group_name         = "some-parameter-group-name"
+    # family                                = "aurora5.6"
+    # kms_key_id                            = "some-kms-key-id"
+    # options                               = []
+    # parameters                            = []
+    # publicly_accessible                   = false
+    # replica_instances                     = 1
+    # storage_encrypted                     = false
+
+    ##################
+    # RDS Monitoring
+    ##################
+
+    # alarm_cpu_limit              = 60
+    # alarm_read_iops_limit        = 100000
+    # alarm_write_iops_limit       = 100000
+    # existing_monitoring_role_arn = ""
+    # notification_topic           = "arn:aws:sns:<region>:<account>:some-topic"
+    # monitoring_interval          = 0
+    # rackspace_alarms_enabled     = false
+
+    ##################
+    # Authentication information
+    ##################
+
+    # username = "dbadmin"
+
+    ##################
+    # Other parameters
+    ##################
+
+    # environment = "Production"
+
+    # tags = {
+    #   SomeTag = "SomeValue"
+    # }
   }
 
-  ##################
-  # Required Configuration
-  ##################
-
-  subnets           = "${module.vpc_dr.private_subnets}"
-  security_groups   = ["${module.vpc_dr.default_sg}"]
-  name              = "sample-aurora-replica"
+  binlog_format     = "MIXED"
   engine            = "aurora"
   instance_class    = "db.t2.medium"
+  kms_key_id        = data.aws_kms_alias.rds_crr.target_key_arn
+  name              = "sample-aurora-replica"
+  password          = data.aws_kms_secrets.rds_credentials.plaintext["password"]
+  security_groups   = [module.vpc_dr.default_sg]
+  source_cluster    = module.aurora_master.cluster_id
+  source_region     = data.aws_region.current.name
   storage_encrypted = true
-  kms_key_id        = "${data.aws_kms_alias.rds_crr.target_key_arn}"
-  binlog_format     = "MIXED"
-  password          = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
-  source_cluster    = "${module.aurora_master.cluster_id}"
-  source_region     = "${data.aws_region.current.name}"
-
-  ##################
-  # VPC Configuration
-  ##################
-
-  # existing_subnet_group = "some-subnet-group-name"
-
-  ##################
-  # Backups and Maintenance
-  ##################
-
-  # maintenance_window      = "Sun:07:00-Sun:08:00"
-  # backup_retention_period = 35
-  # backup_window           = "05:00-06:00"
-  # db_snapshot_arn          = "some-cluster-snapshot-arn"
-
-  ##################
-  # Basic RDS
-  ##################
-
-  # dbname         = "mydb"
-  # engine_version = "5.6.10a"
-  # port           = "3306"
-
-  ##################
-  # RDS Advanced
-  ##################
-
-  # publicly_accessible                   = false
-  # binlog_format                         = "OFF"
-  # auto_minor_version_upgrade            = true
-  # family                                = "aurora5.6"
-  # replica_instances                     = 1
-  # storage_encrypted                     = false
-  # kms_key_id                            = "some-kms-key-id"
-  # parameters                            = []
-  # existing_parameter_group_name         = "some-parameter-group-name"
-  # cluster_parameters                    = []
-  # existing_cluster_parameter_group_name = "some-parameter-group-name"
-  # options                               = []
-  # existing_option_group_name            = "some-option-group-name"
-
-  ##################
-  # RDS Monitoring
-  ##################
-
-  # notification_topic           = "arn:aws:sns:<region>:<account>:some-topic"
-  # alarm_write_iops_limit       = 100000
-  # alarm_read_iops_limit        = 100000
-  # alarm_cpu_limit              = 60
-  # rackspace_alarms_enabled     = false
-  # monitoring_interval          = 0
-  # existing_monitoring_role_arn = ""
-
-  ##################
-  # Authentication information
-  ##################
-
-  # username = "dbadmin"
-
-  ##################
-  # Other parameters
-  ##################
-
-  # environment = "Production"
-
-  # tags = {
-  #   SomeTag = "SomeValue"
-  # }
+  subnets           = module.vpc_dr.private_subnets
 }
+

--- a/examples/aurora_mysql.tf
+++ b/examples/aurora_mysql.tf
@@ -3,13 +3,13 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.1"
   region  = "us-east-1"
+  version = "~> 2.1"
 }
 
 provider "aws" {
-  region = "us-west-2"
   alias  = "oregon"
+  region = "us-west-2"
 }
 
 data "aws_kms_secrets" "rds_credentials" {
@@ -22,17 +22,17 @@ data "aws_kms_secrets" "rds_credentials" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
 
-  vpc_name = "Test1VPC"
+  name = "Test1VPC"
 }
 
 module "vpc_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
 
   providers = {
-    aws = "aws.oregon"
+    aws = aws.oregon
   }
 
-  vpc_name = "Test2VPC"
+  name = "Test2VPC"
 }
 
 module "aurora_mysql_master" {
@@ -42,14 +42,14 @@ module "aurora_mysql_master" {
   # Required Configuration
   ##################
 
-  subnets           = "${module.vpc.private_subnets}"
-  security_groups   = ["${module.vpc.default_sg}"]
-  name              = "sample-aurora-mysql-master"
+  binlog_format     = "MIXED"
   engine            = "aurora-mysql"
   instance_class    = "db.t2.medium"
+  name              = "sample-aurora-mysql-master"
+  password          = data.aws_kms_secrets.rds_credentials.plaintext["password"]
+  security_groups   = [module.vpc.default_sg]
   storage_encrypted = true
-  binlog_format     = "MIXED"
-  password          = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
+  subnets           = module.vpc.private_subnets
 
   ##################
   # VPC Configuration
@@ -72,42 +72,42 @@ module "aurora_mysql_master" {
 
   # dbname         = "mydb"
   # engine_version = "5.7.12"
+  # instance_availability_zone_list          = ["us-west-2a", "us-west-2b", "us-west-2a"]
   # port           = "3306"
   # replica_instances                        = 2
-  # instance_availability_zone_list          = ["us-west-2a", "us-west-2b", "us-west-2a"]
 
   ##################
   # RDS Advanced
   ##################
 
-  # publicly_accessible                   = false
-  # binlog_format                         = "OFF"
   # auto_minor_version_upgrade            = true
-  # family                                = "aurora-mysql5.7"
-  # replica_instances                     = 1
-  # storage_encrypted                     = false
-  # kms_key_id                            = "some-kms-key-id"
-  # parameters                            = []
-  # existing_parameter_group_name         = "some-parameter-group-name"
+  # binlog_format                         = "OFF"
   # cluster_parameters                    = []
   # existing_cluster_parameter_group_name = "some-parameter-group-name"
-  # options                               = []
   # existing_option_group_name            = "some-option-group-name"
+  # existing_parameter_group_name         = "some-parameter-group-name"
+  # family                                = "aurora-mysql5.7"
+  # kms_key_id                            = "some-kms-key-id"
+  # options                               = []
+  # replica_instances                     = 1
+  # parameters                            = []
+  # publicly_accessible                   = false
+  # storage_encrypted                     = false
 
   ##################
   # RDS Monitoring
   ##################
 
-  # notification_topic              = "arn:aws:sns:<region>:<account>:some-topic"
-  # alarm_write_iops_limit          = 100000
-  # alarm_read_iops_limit           = 100000
   # alarm_cpu_limit                 = 60
-  # rackspace_alarms_enabled        = false
-  # monitoring_interval             = 0
-  # existing_monitoring_role_arn    = ""
+  # alarm_read_iops_limit           = 100000
+  # alarm_write_iops_limit          = 100000
   # cloudwatch_logs_exports         = []
+  # existing_monitoring_role_arn    = ""
+  # monitoring_interval             = 0
+  # notification_topic              = "arn:aws:sns:<region>:<account>:some-topic"
   # performance_insights_enable     = false
   # performance_insights_kms_key_id = ""
+  # rackspace_alarms_enabled        = false
 
   ##################
   # Authentication information
@@ -127,99 +127,99 @@ module "aurora_mysql_master" {
 }
 
 data "aws_kms_alias" "rds_crr" {
-  provider = "aws.oregon"
   name     = "alias/aws/rds"
+  provider = aws.oregon
 }
 
 module "aurora_mysql_replica" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-aurora//?ref=v0.12.1"
 
   providers = {
-    aws = "aws.oregon"
+    aws = aws.oregon
+    ##################
+    # Required Configuration
+    ##################
+
+    ##################
+    # VPC Configuration
+    ##################
+
+    # existing_subnet_group = "some-subnet-group-name"
+
+    ##################
+    # Backups and Maintenance
+    ##################
+
+    # backup_retention_period = 35
+    # backup_window           = "05:00-06:00"
+    # db_snapshot_arn          = "some-cluster-snapshot-arn"
+    # maintenance_window      = "Sun:07:00-Sun:08:00"
+
+    ##################
+    # Basic RDS
+    ##################
+
+    # dbname         = "mydb"
+    # engine_version = "5.7.12"
+    # port           = "3306"
+
+    ##################
+    # RDS Advanced
+    ##################
+
+    # auto_minor_version_upgrade            = true
+    # binlog_format                         = "OFF"
+    # cluster_parameters                    = []
+    # existing_cluster_parameter_group_name = "some-parameter-group-name"
+    # existing_option_group_name            = "some-option-group-name"
+    # existing_parameter_group_name         = "some-parameter-group-name"
+    # family                                = "aurora-mysql5.7"
+    # kms_key_id                            = "some-kms-key-id"
+    # options                               = []
+    # parameters                            = []
+    # publicly_accessible                   = false
+    # replica_instances                     = 1
+    # storage_encrypted                     = false
+
+    ##################
+    # RDS Monitoring
+    ##################
+
+    # alarm_cpu_limit              = 60
+    # alarm_read_iops_limit        = 100000
+    # alarm_write_iops_limit       = 100000
+    # existing_monitoring_role_arn = ""
+    # monitoring_interval          = 0
+    # notification_topic           = "arn:aws:sns:<region>:<account>:some-topic"
+    # rackspace_alarms_enabled     = false
+
+    ##################
+    # Authentication information
+    ##################
+
+    # username = "dbadmin"
+
+    ##################
+    # Other parameters
+    ##################
+
+    # environment = "Production"
+
+    # tags = {
+    #   SomeTag = "SomeValue"
+    # }
   }
 
-  ##################
-  # Required Configuration
-  ##################
-
-  subnets           = "${module.vpc_dr.private_subnets}"
-  security_groups   = ["${module.vpc_dr.default_sg}"]
-  name              = "sample-aurora-mysql-replica"
+  binlog_format     = "MIXED"
   engine            = "aurora-mysql"
   instance_class    = "db.t2.medium"
+  kms_key_id        = data.aws_kms_alias.rds_crr.target_key_arn
+  name              = "sample-aurora-mysql-replica"
+  password          = data.aws_kms_secrets.rds_credentials.plaintext["password"]
+  security_groups   = [module.vpc_dr.default_sg]
+  source_cluster    = module.aurora_mysql_master.cluster_id
+  source_region     = data.aws_region.current.name
   storage_encrypted = true
-  kms_key_id        = "${data.aws_kms_alias.rds_crr.target_key_arn}"
-  binlog_format     = "MIXED"
-  password          = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
-  source_cluster    = "${module.aurora_mysql_master.cluster_id}"
-  source_region     = "${data.aws_region.current.name}"
-
-  ##################
-  # VPC Configuration
-  ##################
-
-  # existing_subnet_group = "some-subnet-group-name"
-
-  ##################
-  # Backups and Maintenance
-  ##################
-
-  # maintenance_window      = "Sun:07:00-Sun:08:00"
-  # backup_retention_period = 35
-  # backup_window           = "05:00-06:00"
-  # db_snapshot_arn          = "some-cluster-snapshot-arn"
-
-  ##################
-  # Basic RDS
-  ##################
-
-  # dbname         = "mydb"
-  # engine_version = "5.7.12"
-  # port           = "3306"
-
-  ##################
-  # RDS Advanced
-  ##################
-
-  # publicly_accessible                   = false
-  # binlog_format                         = "OFF"
-  # auto_minor_version_upgrade            = true
-  # family                                = "aurora-mysql5.7"
-  # replica_instances                     = 1
-  # storage_encrypted                     = false
-  # kms_key_id                            = "some-kms-key-id"
-  # parameters                            = []
-  # existing_parameter_group_name         = "some-parameter-group-name"
-  # cluster_parameters                    = []
-  # existing_cluster_parameter_group_name = "some-parameter-group-name"
-  # options                               = []
-  # existing_option_group_name            = "some-option-group-name"
-
-  ##################
-  # RDS Monitoring
-  ##################
-
-  # notification_topic           = "arn:aws:sns:<region>:<account>:some-topic"
-  # alarm_write_iops_limit       = 100000
-  # alarm_read_iops_limit        = 100000
-  # alarm_cpu_limit              = 60
-  # rackspace_alarms_enabled     = false
-  # monitoring_interval          = 0
-  # existing_monitoring_role_arn = ""
-
-  ##################
-  # Authentication information
-  ##################
-
-  # username = "dbadmin"
-
-  ##################
-  # Other parameters
-  ##################
-
-  # environment = "Production"
-
-  # tags = {
-  #   SomeTag = "SomeValue"
-  # }
+  subnets           = module.vpc_dr.private_subnets
 }
+

--- a/examples/aurora_postgres.tf
+++ b/examples/aurora_postgres.tf
@@ -3,13 +3,13 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.1"
   region  = "us-east-1"
+  version = "~> 2.1"
 }
 
 provider "aws" {
-  region = "us-west-2"
   alias  = "oregon"
+  region = "us-west-2"
 }
 
 data "aws_kms_secrets" "rds_credentials" {
@@ -22,7 +22,7 @@ data "aws_kms_secrets" "rds_credentials" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
 
-  vpc_name = "Test1VPC"
+  name = "Test1VPC"
 }
 
 module "aurora_postgresql_master" {
@@ -32,13 +32,13 @@ module "aurora_postgresql_master" {
   # Required Configuration
   ##################
 
-  subnets           = "${module.vpc.private_subnets}"
-  security_groups   = ["${module.vpc.default_sg}"]
-  name              = "sample-aurora-postgresql-master"
   engine            = "aurora-postgresql"
   instance_class    = "db.r4.large"
+  name              = "sample-aurora-postgresql-master"
+  password          = data.aws_kms_secrets.rds_credentials.plaintext["password"]
+  security_groups   = [module.vpc.default_sg]
   storage_encrypted = true
-  password          = "${data.aws_kms_secrets.rds_credentials.plaintext["password"]}"
+  subnets           = module.vpc.private_subnets
 
   ##################
   # VPC Configuration
@@ -50,10 +50,10 @@ module "aurora_postgresql_master" {
   # Backups and Maintenance
   ##################
 
-  # maintenance_window      = "Sun:07:00-Sun:08:00"
   # backup_retention_period = 35
   # backup_window           = "05:00-06:00"
   # db_snapshot_arn         = "some-cluster-snapshot-arn"
+  # maintenance_window      = "Sun:07:00-Sun:08:00"
 
   ##################
   # Basic RDS
@@ -61,42 +61,42 @@ module "aurora_postgresql_master" {
 
   # dbname         = "mydb"
   # engine_version = "9.6.8"
+  # instance_availability_zone_list          = ["us-west-2a", "us-west-2b", "us-west-2a"]
   # port           = "5432"
   # replica_instances                        = 2
-  # instance_availability_zone_list          = ["us-west-2a", "us-west-2b", "us-west-2a"]
 
   ##################
   # RDS Advanced
   ##################
 
-  # publicly_accessible                   = false
-  # binlog_format                         = "OFF"
   # auto_minor_version_upgrade            = true
-  # family                                = "aurora-postgresql9.6"
-  # replica_instances                     = 1
-  # storage_encrypted                     = false
-  # kms_key_id                            = "some-kms-key-id"
-  # parameters                            = []
-  # existing_parameter_group_name         = "some-parameter-group-name"
+  # binlog_format                         = "OFF"
   # cluster_parameters                    = []
   # existing_cluster_parameter_group_name = "some-parameter-group-name"
-  # options                               = []
   # existing_option_group_name            = "some-option-group-name"
+  # existing_parameter_group_name         = "some-parameter-group-name"
+  # family                                = "aurora-postgresql9.6"
+  # kms_key_id                            = "some-kms-key-id"
+  # replica_instances                     = 1
+  # options                               = []
+  # parameters                            = []
+  # publicly_accessible                   = false
+  # storage_encrypted                     = false
 
   ##################
   # RDS Monitoring
   ##################
 
-  # notification_topic              = "arn:aws:sns:<region>:<account>:some-topic"
-  # alarm_write_iops_limit          = 100000
-  # alarm_read_iops_limit           = 100000
   # alarm_cpu_limit                 = 60
-  # rackspace_alarms_enabled        = false
-  # monitoring_interval             = 0
-  # existing_monitoring_role_arn    = ""
+  # alarm_read_iops_limit           = 100000
+  # alarm_write_iops_limit          = 100000
   # cloudwatch_logs_exports         = []
+  # existing_monitoring_role_arn    = ""
+  # monitoring_interval             = 0
+  # notification_topic              = "arn:aws:sns:<region>:<account>:some-topic"
   # performance_insights_enable     = false
   # performance_insights_kms_key_id = ""
+  # rackspace_alarms_enabled        = false
 
   ##################
   # Authentication information
@@ -114,3 +114,4 @@ module "aurora_postgresql_master" {
   #   SomeTag = "SomeValue"
   # }
 }
+


### PR DESCRIPTION
* Conversion of examples to 0.12 via `0.12upgrade`
* Reordering of resource properties based on rackspace standards
* Updating external module parameters to match current naming
* Adjust version pinning for AWS provider

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
