### PR TITLE
Remove option group references

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | `string` | `"Development"` | no |
 | existing\_cluster\_parameter\_group\_name | The existing cluster parameter group to use for this instance. (OPTIONAL) | `string` | `""` | no |
 | existing\_monitoring\_role | ARN of an existing enhanced monitoring role to use for this instance. (OPTIONAL) | `string` | `""` | no |
-| existing\_option\_group\_name | The existing option group to use for this instance. (OPTIONAL) | `string` | `""` | no |
 | existing\_parameter\_group\_name | The existing parameter group to use for this instance. (OPTIONAL) | `string` | `""` | no |
 | existing\_subnet\_group | The existing DB subnet group to use for this cluster (OPTIONAL) | `string` | `""` | no |
 | family | Parameter Group Family Name (ex. aurora5.6, aurora-postgresql9.6, aurora-mysql5.7) | `string` | `""` | no |
@@ -111,7 +110,6 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | cluster\_id | The DB Cluster identifier |
 | db\_instance | The DB instance identifier |
 | monitoring\_role | The IAM role used for Enhanced Monitoring |
-| option\_group | The Option Group used by the DB Instance |
 | parameter\_group | The Parameter Group used by the DB Instance |
 | subnet\_group | The DB Subnet Group used by the DB Instance |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,11 +34,6 @@ output "monitoring_role" {
   value       = local.monitoring_role_arn
 }
 
-output "option_group" {
-  description = "The Option Group used by the DB Instance"
-  value       = local.option_group
-}
-
 output "parameter_group" {
   description = "The Parameter Group used by the DB Instance"
   value       = local.parameter_group

--- a/variables.tf
+++ b/variables.tf
@@ -124,12 +124,6 @@ variable "existing_monitoring_role" {
   default     = ""
 }
 
-variable "existing_option_group_name" {
-  description = "The existing option group to use for this instance. (OPTIONAL)"
-  type        = string
-  default     = ""
-}
-
 variable "existing_parameter_group_name" {
   description = "The existing parameter group to use for this instance. (OPTIONAL)"
   type        = string


### PR DESCRIPTION
* The primary resource, `aws_rds_cluster_instance`, has no attribute for option groups, so they don't need to be part of the module. Removing references in main terraform as well as outputs and variables

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
