### PR TITLE
Name prefix workaround removal

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,11 +163,7 @@ resource "aws_db_parameter_group" "db_parameter_group" {
 resource "aws_rds_cluster_parameter_group" "db_cluster_parameter_group" {
   count = var.existing_cluster_parameter_group_name == "" ? 1 : 0
 
-  # This resource does not utilize name_prefix.  This is due to a bug preventing unique names from being generated.
-  # Currently using name directly.  If that proves to be troublesome, we can attempt to generate a
-  # suffix using timestamps.  See https://github.com/terraform-providers/terraform-provider-aws/issues/1739
-  # for further details
-  name = var.name
+  name_prefix = "${var.name}-"
 
   description = "Cluster parameter group for ${var.name}"
   family      = local.family

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -30,6 +30,7 @@ module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.12.0"
 
   name = "${random_string.name_rstring.result}-Aurora-Test1VPC"
+  tags = var.tags
 }
 
 module "aurora_master" {
@@ -46,6 +47,7 @@ module "aurora_master" {
   skip_final_snapshot = true
   storage_encrypted   = true
   subnets             = module.vpc.private_subnets
+  tags                = var.tags
 }
 
 module "aurora_master_with_replicas" {
@@ -68,6 +70,7 @@ module "aurora_master_with_replicas" {
   skip_final_snapshot = true
   storage_encrypted   = true
   subnets             = module.vpc.private_subnets
+  tags                = var.tags
 }
 
 module "aurora_postgres" {
@@ -82,6 +85,7 @@ module "aurora_postgres" {
   skip_final_snapshot = true
   storage_encrypted   = true
   subnets             = module.vpc.private_subnets
+  tags                = var.tags
 }
 
 # Postgres 9 has some special cases with versioning, so this version is explicitly tested
@@ -97,4 +101,5 @@ module "aurora_postgres9" {
   skip_final_snapshot = true
   storage_encrypted   = true
   subnets             = module.vpc.private_subnets
+  tags                = var.tags
 }

--- a/tests/test1/variables.tf
+++ b/tests/test1/variables.tf
@@ -1,0 +1,5 @@
+variable "tags" {
+  description = "Custom tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
* Remove the workaround for `name_prefix` being broken as it's been addressed in the recent AWS provider versions (both 2.x and 3.x)
* Update tests to allow for resource tagging

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
